### PR TITLE
Icon support preparation

### DIFF
--- a/Luminescent/src/astechzgo/luminescent/main/Main.java
+++ b/Luminescent/src/astechzgo/luminescent/main/Main.java
@@ -42,9 +42,10 @@ public class Main
 		TextureList.loadNonSlickTextures();
 		try
 		{
-			//DisplayUtils.setIcons(
-			//	new String[] {"icons.icon_16x16","icons.icon_32x32","icons.icon_64x64","icons.icon_128x128"}, this
-			//);
+			// Currently does nothing 
+			DisplayUtils.setIcons(
+				new String[] {"icons.icon_16x16","icons.icon_32x32","icons.icon_64x64","icons.icon_128x128"}
+			);
 			DisplayUtils.create();
 		}
 		catch (Exception e)

--- a/Luminescent/src/astechzgo/luminescent/textures/Texture.java
+++ b/Luminescent/src/astechzgo/luminescent/textures/Texture.java
@@ -25,13 +25,16 @@ public class Texture {
 	public Texture(String textureName, boolean slick) {
 		name = textureName;
 		
-		asBufferedImage = toBufferedImage(textureName);
-		asByteBuffer = toByteBuffer(asBufferedImage);
-		
-		if(slick)
-			textureNumber = loadTexture();
-		else
+		if(!slick) {
 			textureNumber = -1;
+			asBufferedImage = toBufferedImage(textureName);
+			asByteBuffer = toByteBuffer(asBufferedImage);
+		}
+		else {
+			asBufferedImage = toBufferedImage(textureName);
+			asByteBuffer = toByteBuffer(asBufferedImage);
+			textureNumber = loadTexture();
+		}
 	}
 	
 	/**
@@ -99,7 +102,10 @@ public class Texture {
 		bGr.dispose();
 
 		// Return the buffered image
-		return getFlippedImage(bimage);
+		if(textureNumber == -1)
+			return bimage;
+		else
+			return getFlippedImage(bimage);
 	}
 	
 	private int loadTexture() {

--- a/Luminescent/src/astechzgo/luminescent/utils/DisplayUtils.java
+++ b/Luminescent/src/astechzgo/luminescent/utils/DisplayUtils.java
@@ -70,6 +70,9 @@ public class DisplayUtils {
 	public static int oldGameWidth = getDisplayWidth() - widthOffset * 2;
 	public static int oldGameHeight = getDisplayHeight() - heightOffset * 2;
 	
+	@SuppressWarnings("unused")
+	private static GLFWImage.Buffer icons;
+	
 	public static GLCapabilities caps;
 
 	static {
@@ -215,6 +218,9 @@ public class DisplayUtils {
 
 			GLFW.glfwSetKeyCallback(handle, KeyboardUtils.KEY_CALLBACK);
 			
+//			Uncomment when updated to new LWJGL release
+//			GLFW.glfwSetWindowIcon(handle, icons);
+			
 			
 		} catch (Exception e) {
 			System.out.println("Unable to setup mode " + width + "x" + height
@@ -239,9 +245,8 @@ public class DisplayUtils {
 			
 			icons.position(i++).width(width).height(height).pixels(buffer);
 		}
-
-//		Uncomment when updated to new LWJGL release
-//		GLFW.glfwSetWindowIcon(handle, icons);
+		
+		DisplayUtils.icons = icons;
 	}
 
 	public static void takeScreenshot(File file) throws Exception {
@@ -352,6 +357,9 @@ public class DisplayUtils {
 		
 		glfwMakeContextCurrent(handle);
 		caps = GL.createCapabilities();
+		
+//		Uncomment when updated to new LWJGL release
+//		GLFW.glfwSetWindowIcon(handle, icons);
 		
 		glfwSwapInterval(1);
 		glfwShowWindow(handle);

--- a/Luminescent/src/astechzgo/luminescent/utils/DisplayUtils.java
+++ b/Luminescent/src/astechzgo/luminescent/utils/DisplayUtils.java
@@ -26,13 +26,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.imageio.ImageIO;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWImage;
 import org.lwjgl.glfw.GLFWVidMode;
 import org.lwjgl.glfw.GLFWVidMode.Buffer;
 import org.lwjgl.opengl.GL;
@@ -227,18 +226,22 @@ public class DisplayUtils {
 	/**
 	 * Sets the icons for display
 	 * 
-	 * @param nIcon
-	 *            The locations of the icons
-	 * @param c
-	 *            A random object
+	 * @param nIcon The locations of the icons
 	 */
-	public static void setIcons(String[] nIcon, Object c) {
-		List<ByteBuffer> icons = new ArrayList<ByteBuffer>();
+	public static void setIcons(String[] nIcon) {
+		GLFWImage.Buffer icons = GLFWImage.callocBuffer(nIcon.length);
+		
+		int i = 0;
 		for (String name : nIcon) {
-			icons.add(TextureList.findTexture(name).getAsByteBuffer());
+			ByteBuffer buffer = TextureList.findTexture(name).getAsByteBuffer();
+			int width = TextureList.findTexture(name).getAsBufferedImage().getWidth();
+			int height = TextureList.findTexture(name).getAsBufferedImage().getHeight();
+			
+			icons.position(i++).width(width).height(height).pixels(buffer);
 		}
 
-		//Display.setIcon(icons.toArray(new ByteBuffer[icons.size()]));
+//		Uncomment when updated to new LWJGL release
+//		GLFW.glfwSetWindowIcon(handle, icons);
 	}
 
 	public static void takeScreenshot(File file) throws Exception {


### PR DESCRIPTION
Now that icons support has been added to LWJGL3 nightly builds, it is possible to test for future features that will be available to Luminescent.  This has been tested on the latest nightly build. 
